### PR TITLE
Force the source and target compatibility to Java 7.

### DIFF
--- a/schematic-annotations/build.gradle
+++ b/schematic-annotations/build.gradle
@@ -1,6 +1,9 @@
 apply plugin: 'java'
 apply plugin: 'checkstyle'
 
+targetCompatibility = JavaVersion.VERSION_1_7
+sourceCompatibility = JavaVersion.VERSION_1_7
+
 checkstyle {
   configFile project.file('../config/checkstyle/checkstyle.xml')
   showViolations true

--- a/schematic-compiler/build.gradle
+++ b/schematic-compiler/build.gradle
@@ -1,6 +1,9 @@
 apply plugin: 'java'
 apply plugin: 'checkstyle'
 
+targetCompatibility = JavaVersion.VERSION_1_7
+sourceCompatibility = JavaVersion.VERSION_1_7
+
 dependencies {
   compile project(':schematic-annotations')
   compile parent.ext.libraries.javawriter

--- a/schematic-samples/build.gradle
+++ b/schematic-samples/build.gradle
@@ -28,6 +28,11 @@ android {
   compileSdkVersion parent.ext.compileSdkVersion
   buildToolsVersion parent.ext.buildToolsVersion
 
+  compileOptions {
+    sourceCompatibility JavaVersion.VERSION_1_7
+    targetCompatibility JavaVersion.VERSION_1_7
+  }
+
   defaultConfig {
     minSdkVersion = parent.ext.minSdkVersion
     targetSdkVersion = parent.ext.targetSdkVersion

--- a/schematic/build.gradle
+++ b/schematic/build.gradle
@@ -19,6 +19,11 @@ android {
   compileSdkVersion parent.ext.compileSdkVersion
   buildToolsVersion parent.ext.buildToolsVersion
 
+  compileOptions {
+    sourceCompatibility JavaVersion.VERSION_1_7
+    targetCompatibility JavaVersion.VERSION_1_7
+  }
+
   defaultConfig {
     minSdkVersion = parent.ext.minSdkVersion
     targetSdkVersion = parent.ext.targetSdkVersion


### PR DESCRIPTION
Previously if you built with Java 8 the java artifacts would have a class level of 8 whereas the Android ones would stay at 7.
