### PR TITLE
Compound primary keys

### DIFF
--- a/schematic-compiler/src/main/java/net/simonvt/schematic/compiler/TableWriter.java
+++ b/schematic-compiler/src/main/java/net/simonvt/schematic/compiler/TableWriter.java
@@ -88,6 +88,8 @@ public class TableWriter {
 
   public void createTable(JavaWriter writer) throws IOException {
     StringBuilder query = new StringBuilder("\"CREATE TABLE " + name + " (");
+    
+    List<String> primaryKeys = new ArrayList<String>();
 
     boolean first = true;
     for (VariableElement element : columns) {
@@ -121,7 +123,7 @@ public class TableWriter {
 
       PrimaryKey primary = element.getAnnotation(PrimaryKey.class);
       if (primary != null) {
-        query.append(" ").append("PRIMARY KEY");
+        primaryKeys.add(columnName);
       }
 
       AutoIncrement autoIncrement = element.getAnnotation(AutoIncrement.class);
@@ -138,6 +140,21 @@ public class TableWriter {
             .append(references.column())
             .append(")");
       }
+    }
+    
+    // Works with one (default) primary keys or compound keys
+    if (primaryKeys.size() > 0) {
+      query.append(", PRIMARY KEY (");
+      first = true;
+      for (String columnName : primaryKeys) {
+        if (!first) {
+          query.append(",");
+        } else {
+          first = false;
+        }
+        query.append(columnName);
+      }
+      query.append(")");
     }
 
     query.append(")\"");


### PR DESCRIPTION
Hello Simon!

I've a case where I need a compound key in a table, and I saw that, when I add `@PrimaryKey` to more than one field on my contract, it generates an invalid SQL, for example:

``` sql
CREATE TABLE foo(
  _id INTEGER NOT NULL PRIMARY KEY,
  second_id INTEGER NOT NULL PRIMARY KEY,
  bar TEXT
)
```

When the correct equivalent would be:

``` sql
CREATE TABLE foo(
  _id INTEGER NOT NULL,
  second_id INTEGER NOT NULL,
  bar TEXT,
  PRIMARY KEY (_id, second_id)
)
```

So, I made this change to use only the second form, what is correct when using only one field or more in the `PRIMARY KEY ()` clause.

I think that it is not a common case, but is useful. :)
