### PR TITLE
Added break statements to the batch insert switch statement.

### DIFF
--- a/schematic-compiler/src/main/java/net/simonvt/schematic/compiler/ContentProviderWriter.java
+++ b/schematic-compiler/src/main/java/net/simonvt/schematic/compiler/ContentProviderWriter.java
@@ -514,6 +514,7 @@ public class ContentProviderWriter {
       if (uri.allowInsert) {
         writer.beginControlFlow("case " + uri.name + ":")
             .emitStatement("insertValues(db, \"%s\", values)", uri.table)
+            .emitStatement("break")
             .endControlFlow();
       }
     }


### PR DESCRIPTION
The switch statement for batch insertion was missing breaks, causing the inserts to cascade across subsequent cases.
