### PR TITLE
Set minSdkVersion value to 4 for Android 1.6+ support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ ext {
   versionCode = 1
   versionName = '0.6.2'
 
-  minSdkVersion = 15
+  minSdkVersion = 4
   targetSdkVersion = 22
 
   compileSdkVersion = 22


### PR DESCRIPTION
Would like to use this library on my existing project, but minSdkVersion = 15 is too high. Can't see any reason why it couldn't be lower. 4 seems to work fine, that's what support-v4 needs.