### PR TITLE
Add support for SQLiteOpenHelper.onConfigure()

### DIFF
--- a/schematic-annotations/src/main/java/net/simonvt/schematic/annotation/OnConfigure.java
+++ b/schematic-annotations/src/main/java/net/simonvt/schematic/annotation/OnConfigure.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2015 Adam Stroud
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.simonvt.schematic.annotation;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.CLASS;
+
+/**
+ * Method to be called when configuring the database.
+ * <pre>{@code
+ * &#064;OnUpgrade public static void onUpgrade(SQLiteDatabase db) {
+ *   ...
+ * }
+ * }</pre>
+ */
+@Retention(CLASS) @Target(METHOD)
+public @interface OnConfigure {
+}

--- a/schematic-annotations/src/main/java/net/simonvt/schematic/annotation/OnConfigure.java
+++ b/schematic-annotations/src/main/java/net/simonvt/schematic/annotation/OnConfigure.java
@@ -25,7 +25,7 @@ import static java.lang.annotation.RetentionPolicy.CLASS;
 /**
  * Method to be called when configuring the database.
  * <pre>{@code
- * &#064;OnUpgrade public static void onUpgrade(SQLiteDatabase db) {
+ * &#064;OnConfigure public static void onConfigure(SQLiteDatabase db) {
  *   ...
  * }
  * }</pre>

--- a/schematic-samples/src/main/java/net/simonvt/schematic/sample/database/NotesDatabase.java
+++ b/schematic-samples/src/main/java/net/simonvt/schematic/sample/database/NotesDatabase.java
@@ -18,7 +18,9 @@ package net.simonvt.schematic.sample.database;
 
 import android.content.Context;
 import android.database.sqlite.SQLiteDatabase;
+
 import net.simonvt.schematic.annotation.Database;
+import net.simonvt.schematic.annotation.OnConfigure;
 import net.simonvt.schematic.annotation.OnCreate;
 import net.simonvt.schematic.annotation.OnUpgrade;
 import net.simonvt.schematic.annotation.Table;
@@ -44,5 +46,8 @@ public final class NotesDatabase {
 
   @OnUpgrade public static void onUpgrade(Context context, SQLiteDatabase db, int oldVersion,
       int newVersion) {
+  }
+
+  @OnConfigure public static void onConfigure(SQLiteDatabase db) {
   }
 }


### PR DESCRIPTION
This hook will allow users to easily add calls to enable foreign constraints and/or WAL as they can be called from [onConfigure()](https://developer.android.com/reference/android/database/sqlite/SQLiteOpenHelper.html#onConfigure(android.database.sqlite.SQLiteDatabase)).