### PR TITLE
Added try..finally generation for each beginTransaction - endTransactio…

### DIFF
--- a/schematic-compiler/src/main/java/net/simonvt/schematic/compiler/ContentProviderWriter.java
+++ b/schematic-compiler/src/main/java/net/simonvt/schematic/compiler/ContentProviderWriter.java
@@ -510,6 +510,7 @@ public class ContentProviderWriter {
         .emitField("SQLiteDatabase", "db", EnumSet.of(Modifier.FINAL),
             "database.getWritableDatabase()")
         .emitStatement("db.beginTransaction()")
+        .beginControlFlow("try")
         .emitEmptyLine();
 
     writer.beginControlFlow("switch(MATCHER.match(uri))");
@@ -525,7 +526,9 @@ public class ContentProviderWriter {
 
     writer.emitEmptyLine()
         .emitStatement("db.setTransactionSuccessful()")
+        .nextControlFlow("finally")
         .emitStatement("db.endTransaction()")
+        .endControlFlow()
         .emitStatement("getContext().getContentResolver().notifyChange(uri, null)")
         .emitStatement("return values.length")
         .endMethod()
@@ -536,10 +539,14 @@ public class ContentProviderWriter {
         .beginMethod("ContentProviderResult[]", "applyBatch", EnumSet.of(Modifier.PUBLIC),
             Arrays.asList("ArrayList<ContentProviderOperation>", "ops"),
             Arrays.asList("OperationApplicationException"))
+        .emitStatement("ContentProviderResult[] results")
         .emitStatement("database.getWritableDatabase().beginTransaction()")
-        .emitStatement("ContentProviderResult[] results = super.applyBatch(ops)")
+        .beginControlFlow("try")
+        .emitStatement("results = super.applyBatch(ops)")
         .emitStatement("database.getWritableDatabase().setTransactionSuccessful()")
+        .nextControlFlow("finally")
         .emitStatement("database.getWritableDatabase().endTransaction()")
+        .endControlFlow()
         .emitStatement("return results")
         .endMethod();
 


### PR DESCRIPTION
According to [beginTransaction()](http://developer.android.com/reference/android/database/sqlite/SQLiteDatabase.html#beginTransaction()) documentation the standard idiom for transactions is:
```
   db.beginTransaction();
   try {
     ...
     db.setTransactionSuccessful();
   } finally {
     db.endTransaction();
   }
```
Schematic violates this idiom. This pull request fix it. This is important because if we receive error during sql operation (eg. unique constraint violation, not null constraint violation etc) transaction will not be ended. That leads to unavailable database for all further operations.

Here are examples of generated code before changes and after changes.

`applyBatch` before changes
```
  @Override
  public ContentProviderResult[] applyBatch(ArrayList<ContentProviderOperation> ops)
      throws OperationApplicationException {
    database.getWritableDatabase().beginTransaction();
    ContentProviderResult[] results = super.applyBatch(ops);
    database.getWritableDatabase().setTransactionSuccessful();
    database.getWritableDatabase().endTransaction();
    return results;
  }
```
`applyBatch` after changes
```
  @Override
  public ContentProviderResult[] applyBatch(ArrayList<ContentProviderOperation> ops)
      throws OperationApplicationException {
    ContentProviderResult[] results;
    database.getWritableDatabase().beginTransaction();
    try {
      results = super.applyBatch(ops);
      database.getWritableDatabase().setTransactionSuccessful();
    } finally {
      database.getWritableDatabase().endTransaction();
    }
    return results;
  }
```
`bulkInsert` before changes
```
@Override
  public int bulkInsert(Uri uri, ContentValues[] values) {
    final SQLiteDatabase db = database.getWritableDatabase();
    db.beginTransaction();

    switch(MATCHER.match(uri)) {
      case LISTS_CONTENT_URI: {
        insertValues(db, "lists", values);
        break;
      }
      case LISTS_LIST_ID: {
        insertValues(db, "lists", values);
        break;
      }
      case NOTES_CONTENT_URI: {
        insertValues(db, "notes", values);
        break;
      }
      case NOTES_NOTE_ID: {
        insertValues(db, "notes", values);
        break;
      }
      case NOTES_NOTES_FROM_LIST: {
        insertValues(db, "notes", values);
        break;
      }
    }

    db.setTransactionSuccessful();
    db.endTransaction();
    getContext().getContentResolver().notifyChange(uri, null);
    return values.length;
  }
```
`bulkInsert` after changes
```
  @Override
  public int bulkInsert(Uri uri, ContentValues[] values) {
    final SQLiteDatabase db = database.getWritableDatabase();
    db.beginTransaction();
    try {

      switch(MATCHER.match(uri)) {
        case LISTS_CONTENT_URI: {
          insertValues(db, "lists", values);
          break;
        }
        case LISTS_LIST_ID: {
          insertValues(db, "lists", values);
          break;
        }
        case NOTES_CONTENT_URI: {
          insertValues(db, "notes", values);
          break;
        }
        case NOTES_NOTE_ID: {
          insertValues(db, "notes", values);
          break;
        }
        case NOTES_NOTES_FROM_LIST: {
          insertValues(db, "notes", values);
          break;
        }
      }

      db.setTransactionSuccessful();
    } finally {
      db.endTransaction();
    }
    getContext().getContentResolver().notifyChange(uri, null);
    return values.length;
  }
```