### PR TITLE
added on conflict resolution for primary key and not null

### DIFF
--- a/schematic-annotations/src/main/java/net/simonvt/schematic/annotation/ConflictResolutionType.java
+++ b/schematic-annotations/src/main/java/net/simonvt/schematic/annotation/ConflictResolutionType.java
@@ -1,0 +1,13 @@
+package net.simonvt.schematic.annotation;
+
+/**
+ * conflict resolution algorithms
+ */
+public enum ConflictResolutionType {
+  NONE,
+  ROLLBACK,
+  ABORT,
+  FAIL,
+  IGNORE,
+  REPLACE,
+}

--- a/schematic-annotations/src/main/java/net/simonvt/schematic/annotation/NotNull.java
+++ b/schematic-annotations/src/main/java/net/simonvt/schematic/annotation/NotNull.java
@@ -27,4 +27,8 @@ import static java.lang.annotation.RetentionPolicy.CLASS;
  */
 @Retention(CLASS) @Target(FIELD)
 public @interface NotNull {
+    /**
+     * Defines conflict resolution algorithm.
+     */
+    ConflictResolutionType onConflict() default ConflictResolutionType.NONE;
 }

--- a/schematic-annotations/src/main/java/net/simonvt/schematic/annotation/PrimaryKey.java
+++ b/schematic-annotations/src/main/java/net/simonvt/schematic/annotation/PrimaryKey.java
@@ -27,4 +27,8 @@ import static java.lang.annotation.RetentionPolicy.CLASS;
  */
 @Retention(CLASS) @Target(FIELD)
 public @interface PrimaryKey {
+    /**
+     * Defines conflict resolution algorithm. Will be ignored if there are multiple PrimaryKey annotations
+     */
+    ConflictResolutionType onConflict() default ConflictResolutionType.NONE;
 }

--- a/schematic-annotations/src/main/java/net/simonvt/schematic/annotation/Unique.java
+++ b/schematic-annotations/src/main/java/net/simonvt/schematic/annotation/Unique.java
@@ -27,14 +27,9 @@ import static java.lang.annotation.RetentionPolicy.CLASS;
  */
 @Retention(CLASS) @Target(FIELD)
 public @interface Unique {
+  /**
+   * Defines conflict resolution algorithm.
+   */
   ConflictResolutionType onConflict() default ConflictResolutionType.NONE;
 
-  public enum ConflictResolutionType {
-    NONE,
-    ROLLBACK,
-    ABORT,
-    FAIL,
-    IGNORE,
-    REPLACE,
-  }
 }


### PR DESCRIPTION
In case of many `@PrimaryKey` annotations `onConflict` will be ignored.