### PR TITLE
Support for CHECK constraint

### DIFF
--- a/schematic-annotations/src/main/java/net/simonvt/schematic/annotation/Check.java
+++ b/schematic-annotations/src/main/java/net/simonvt/schematic/annotation/Check.java
@@ -1,0 +1,31 @@
+package net.simonvt.schematic.annotation;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.CLASS;
+
+/**
+ * Add CHECK constraint. Can be used on column level or on table level.
+ * <pre>
+ * <code>
+ * &#64;Check(NotesColumns.STATUS + " = '" + NotesColumns.STATUS_COMPLETED + "' and " + NotesColumns.COMPLETION_DATE + " is not null")
+ * public interface NotesColumns{
+ *   String STATUS_NEW = "new";
+ *   String STATUS_COMPLETED = "completed";
+ *   &#64;DataType(TEXT) &#64;CHECK(NotesColumns.STATUS + " in ('"+NotesColumns.STATUS_NEW+"', '"+NotesColumns.STATUS_COMPLETED+"')") String STATUS = "status";
+ *   &#64;DataType(TEXT) String COMPLETION_DATE = "completion_date";
+ * }
+ *
+ * </code>
+ * </pre>
+ */
+@Retention(CLASS) @Target({TYPE, FIELD})
+public @interface Check {
+    /**
+     * CHECK constraint text. Shouldn't contain double quotes. Use single quote instead.
+     */
+    String value();
+}

--- a/schematic-samples/src/main/java/net/simonvt/schematic/sample/database/NoteColumns.java
+++ b/schematic-samples/src/main/java/net/simonvt/schematic/sample/database/NoteColumns.java
@@ -17,6 +17,7 @@
 package net.simonvt.schematic.sample.database;
 
 import net.simonvt.schematic.annotation.AutoIncrement;
+import net.simonvt.schematic.annotation.Check;
 import net.simonvt.schematic.annotation.DataType;
 import net.simonvt.schematic.annotation.PrimaryKey;
 import net.simonvt.schematic.annotation.References;
@@ -26,6 +27,8 @@ import static net.simonvt.schematic.annotation.DataType.Type.INTEGER;
 import static net.simonvt.schematic.annotation.DataType.Type.TEXT;
 
 public interface NoteColumns {
+  String STATUS_NEW = "new";
+  String STATUS_COMPLETED = "completed";
 
   @DataType(INTEGER) @PrimaryKey @AutoIncrement String ID = "_id";
 
@@ -33,4 +36,10 @@ public interface NoteColumns {
       "listId";
 
   @DataType(TEXT) String NOTE = "note";
+
+  @DataType(TEXT)
+  @Check(NoteColumns.STATUS + " in ('" + NoteColumns.STATUS_NEW + "', '"
+          + NoteColumns.STATUS_COMPLETED + "')")
+  String STATUS = "status";
+
 }

--- a/schematic-samples/src/main/java/net/simonvt/schematic/sample/ui/SampleActivity.java
+++ b/schematic-samples/src/main/java/net/simonvt/schematic/sample/ui/SampleActivity.java
@@ -64,8 +64,8 @@ public class SampleActivity extends FragmentActivity
         .commit();
   }
 
-  @Override public void onNoteSelected(long listId, long noteId, String note) {
-    Fragment f = NoteFragment.newInstance(listId, noteId, note);
+  @Override public void onNoteSelected(long listId, long noteId, String note, String status) {
+    Fragment f = NoteFragment.newInstance(listId, noteId, note, status);
     getSupportFragmentManager() //
         .beginTransaction() //
         .replace(android.R.id.content, f, FRAGMENT_NOTE) //

--- a/schematic-samples/src/main/java/net/simonvt/schematic/sample/ui/adapter/ListAdapter.java
+++ b/schematic-samples/src/main/java/net/simonvt/schematic/sample/ui/adapter/ListAdapter.java
@@ -44,10 +44,13 @@ public class ListAdapter extends CursorAdapter {
     ViewHolder vh = (ViewHolder) view.getTag();
     final String note = cursor.getString(cursor.getColumnIndex(NoteColumns.NOTE));
     vh.note.setText(note);
+    final String status = cursor.getString(cursor.getColumnIndex(NoteColumns.STATUS));
+    vh.status.setText(status);
   }
 
   static class ViewHolder {
     @InjectView(R.id.note) TextView note;
+    @InjectView(R.id.statusText) TextView status;
 
     ViewHolder(View v) {
       ButterKnife.inject(this, v);

--- a/schematic-samples/src/main/java/net/simonvt/schematic/sample/ui/fragment/ListFragment.java
+++ b/schematic-samples/src/main/java/net/simonvt/schematic/sample/ui/fragment/ListFragment.java
@@ -48,7 +48,7 @@ public class ListFragment extends Fragment implements LoaderManager.LoaderCallba
 
     void onAddNote(long listId);
 
-    void onNoteSelected(long listId, long noteId, String note);
+    void onNoteSelected(long listId, long noteId, String note, String status);
 
     void onListRemoved();
   }
@@ -140,7 +140,8 @@ public class ListFragment extends Fragment implements LoaderManager.LoaderCallba
   @OnItemClick(android.R.id.list) void onNoteSelected(int position, long noteId) {
     Cursor c = (Cursor) adapter.getItem(position);
     String note = c.getString(c.getColumnIndex(NoteColumns.NOTE));
-    listener.onNoteSelected(listId, noteId, note);
+    String status = c.getString(c.getColumnIndex(NoteColumns.STATUS));
+    listener.onNoteSelected(listId, noteId, note, status);
   }
 
   @Override public Loader<Cursor> onCreateLoader(int id, Bundle args) {

--- a/schematic-samples/src/main/java/net/simonvt/schematic/sample/ui/fragment/NoteFragment.java
+++ b/schematic-samples/src/main/java/net/simonvt/schematic/sample/ui/fragment/NoteFragment.java
@@ -28,6 +28,7 @@ import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.EditText;
+import android.widget.Switch;
 import android.widget.TextView;
 import butterknife.ButterKnife;
 import butterknife.InjectView;
@@ -50,20 +51,23 @@ public class NoteFragment extends Fragment {
   private static final String ARG_ID = "net.simonvt.schematic.samples.ui.fragment.NoteFragment.id";
   private static final String ARG_NOTE =
       "net.simonvt.schematic.samples.ui.fragment.NoteFragment.note";
+  private static final String ARG_STATUS =
+          "net.simonvt.schematic.samples.ui.fragment.NoteFragment.status";
 
   private static final long NO_ID = -1L;
 
   public static NoteFragment newInstance(long listId) {
-    return newInstance(listId, NO_ID, null);
+    return newInstance(listId, NO_ID, null, null);
   }
 
-  public static NoteFragment newInstance(long listId, long id, String note) {
+  public static NoteFragment newInstance(long listId, long id, String note, String status) {
     NoteFragment f = new NoteFragment();
 
     Bundle args = new Bundle();
     args.putLong(ARG_LIST_ID, listId);
     args.putLong(ARG_ID, id);
     args.putString(ARG_NOTE, note);
+    args.putString(ARG_STATUS, status);
     f.setArguments(args);
 
     return f;
@@ -72,12 +76,14 @@ public class NoteFragment extends Fragment {
   private long listId;
   private long noteId;
   private String note;
+  private String status;
 
   private NoteListener listener;
 
   @InjectView(R.id.action) View actionView;
   @InjectView(R.id.actionText) TextView actionText;
   @InjectView(R.id.note) EditText noteView;
+  @InjectView(R.id.statusSwitch) Switch statusView;
 
   @Override public void onAttach(Activity activity) {
     super.onAttach(activity);
@@ -90,6 +96,7 @@ public class NoteFragment extends Fragment {
     listId = args.getLong(ARG_LIST_ID);
     noteId = args.getLong(ARG_ID);
     note = args.getString(ARG_NOTE);
+    status = args.getString(ARG_STATUS);
 
     setHasOptionsMenu(true);
   }
@@ -104,8 +111,10 @@ public class NoteFragment extends Fragment {
     ButterKnife.inject(this, view);
     if (noteId != NO_ID) {
       noteView.setText(note);
+      statusView.setChecked(status == NoteColumns.STATUS_COMPLETED);
       actionText.setText(R.string.update);
     } else {
+      statusView.setChecked(false);
       actionText.setText(R.string.insert);
     }
   }
@@ -138,6 +147,12 @@ public class NoteFragment extends Fragment {
 
   @OnClick(R.id.action) void onAction() {
     final String note = noteView.getText().toString();
+    final String status;
+    if (statusView.isChecked()) {
+      status = NoteColumns.STATUS_COMPLETED;
+    } else {
+      status = NoteColumns.STATUS_NEW;
+    }
     final Context appContext = getActivity().getApplicationContext();
     if (noteId == NO_ID) {
       new Thread(new Runnable() {
@@ -145,6 +160,7 @@ public class NoteFragment extends Fragment {
           ContentValues cv = new ContentValues();
           cv.put(NoteColumns.LIST_ID, listId);
           cv.put(NoteColumns.NOTE, note);
+          cv.put(NoteColumns.STATUS, status);
           appContext.getContentResolver().insert(Notes.CONTENT_URI, cv);
         }
       }).start();
@@ -153,6 +169,7 @@ public class NoteFragment extends Fragment {
         @Override public void run() {
           ContentValues cv = new ContentValues();
           cv.put(NoteColumns.NOTE, note);
+          cv.put(NoteColumns.STATUS, status);
           appContext.getContentResolver().update(Notes.withId(noteId), cv, null, null);
         }
       }).start();

--- a/schematic-samples/src/main/res/layout/fragment_note.xml
+++ b/schematic-samples/src/main/res/layout/fragment_note.xml
@@ -19,7 +19,16 @@
     android:orientation="vertical"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
-
+    <Switch
+        android:id="@+id/statusSwitch"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingLeft="16dp"
+        android:paddingRight="16dp"
+        android:paddingTop="8dp"
+        android:paddingBottom="8dp"
+        android:text="completed"
+        />
   <FrameLayout
       android:layout_width="match_parent"
       android:layout_height="0dp"

--- a/schematic-samples/src/main/res/layout/row_note.xml
+++ b/schematic-samples/src/main/res/layout/row_note.xml
@@ -27,7 +27,17 @@
       android:paddingLeft="16dp"
       android:paddingTop="16dp"
       android:paddingRight="16dp"
-      android:paddingBottom="16dp"
+      android:paddingBottom="4dp"
       android:textAppearance="?android:attr/textAppearanceMedium"
       tools:text="This is a note"/>
+    <TextView
+        android:id="@+id/statusText"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        tools:text="status"
+        android:paddingLeft="16dp"
+        android:paddingRight="16dp"
+        android:paddingBottom="16dp"
+        android:textAppearance="?android:attr/textAppearanceSmall"
+        />
 </LinearLayout>


### PR DESCRIPTION
Added new `@Check` annotation in order to support `CHECK` constraint. New annotation can be applied on column level or on table level.

Usage example:
```
 @Check(NotesColumns.STATUS + " = '" + NotesColumns.STATUS_COMPLETED + "' and " + NotesColumns.COMPLETION_DATE + " is not null")
 public interface NotesColumns{
   String STATUS_NEW = "new";
   String STATUS_COMPLETED = "completed";
   @DataType(TEXT) @CHECK(NotesColumns.STATUS + " in ('"+NotesColumns.STATUS_NEW+"', '"+NotesColumns.STATUS_COMPLETED+"')") String STATUS = "status";
   @DataType(TEXT) String COMPLETION_DATE = "completion_date";
 }
```
Also modified example in order to demonstrate new annotation.