### PR TITLE
Fix javadoc to have correct HTML output for code examples

### DIFF
--- a/schematic-annotations/src/main/java/net/simonvt/schematic/annotation/ContentProvider.java
+++ b/schematic-annotations/src/main/java/net/simonvt/schematic/annotation/ContentProvider.java
@@ -25,15 +25,14 @@ import static java.lang.annotation.RetentionPolicy.CLASS;
 /**
  * The class annotated describes a ContentProvider. For each table in the database, add a {@link
  * net.simonvt.schematic.annotation.TableEndpoint} annotation to an inner class.
- * <pre>{@code
+ * <pre><code>
  * &#064;ContentProvider(authority = NotesProvider.AUTHORITY, database = NotesDatabase.class)
  * public final class NotesProvider {
  *
  *   &#064;TableEndpoint(table = NotesDatabase.LISTS) public static class Lists {
  *     ...
  *   }
- * }
- * }</pre>
+ * }</code></pre>
  */
 @Retention(CLASS) @Target(TYPE)
 public @interface ContentProvider {

--- a/schematic-annotations/src/main/java/net/simonvt/schematic/annotation/ContentUri.java
+++ b/schematic-annotations/src/main/java/net/simonvt/schematic/annotation/ContentUri.java
@@ -25,13 +25,13 @@ import static java.lang.annotation.RetentionPolicy.CLASS;
 /**
  * A content URI is a URI that identifies data in a provider. This has to be used inside a class
  * annotated with {@link net.simonvt.schematic.annotation.TableEndpoint},
- * <pre>{@code
+ * <pre><code>
  * &#064;ContentUri(
  *   path = "lists",
  *   type = "vnd.android.cursor.dir/list",
  *   defaultSort = ListColumns.TITLE + " ASC")
  * public static final Uri LISTS = Uri.parse("content://" + AUTHORITY + "/lists");
- * }</pre>
+ * </code></pre>
  */
 @Retention(CLASS) @Target(FIELD)
 public @interface ContentUri {

--- a/schematic-annotations/src/main/java/net/simonvt/schematic/annotation/Database.java
+++ b/schematic-annotations/src/main/java/net/simonvt/schematic/annotation/Database.java
@@ -24,7 +24,7 @@ import static java.lang.annotation.RetentionPolicy.CLASS;
 
 /**
  * The class annotated describes a SQLiteOpenHelper.
- * <pre>{@code
+ * <pre><code>
  * &#064;Database(version = NotesDatabase.VERSION)
  * public final class NotesDatabase {
  *
@@ -33,8 +33,7 @@ import static java.lang.annotation.RetentionPolicy.CLASS;
  *   &#064;Table(ListColumns.class) public static final String LISTS = "lists";
  *
  *   &#064;Table(NoteColumns.class) public static final String NOTES = "notes";
- * }
- * }</pre>
+ * }</code></pre>
  */
 @Retention(CLASS) @Target(TYPE)
 public @interface Database {

--- a/schematic-annotations/src/main/java/net/simonvt/schematic/annotation/InexactContentUri.java
+++ b/schematic-annotations/src/main/java/net/simonvt/schematic/annotation/InexactContentUri.java
@@ -24,7 +24,7 @@ import static java.lang.annotation.RetentionPolicy.CLASS;
 
 /**
  * An inexact content URI. Annotates the method used to construct the URI.
- * <pre>{@code
+ * <pre><code>
  * &#064;InexactContentUri(
  *   path = Path.LISTS + "/#",
  *   name = "LIST_ID",
@@ -33,8 +33,7 @@ import static java.lang.annotation.RetentionPolicy.CLASS;
  *   pathSegment = 1)
  * public static Uri withId(long id) {
  *   return Uri.parse("content://" + AUTHORITY + "/lists/" + id);
- * }
- * }</pre>
+ * }</code></pre>
  */
 @Retention(CLASS) @Target(METHOD)
 public @interface InexactContentUri {

--- a/schematic-annotations/src/main/java/net/simonvt/schematic/annotation/InsertUri.java
+++ b/schematic-annotations/src/main/java/net/simonvt/schematic/annotation/InsertUri.java
@@ -24,12 +24,11 @@ import static java.lang.annotation.RetentionPolicy.CLASS;
 
 /**
  * Annotate a method that returns an Uri to be returned when performing an insert.
- * <pre>{@code
+ * <pre><code>
  * &#064;InsertUri(paths = "lists)
  * public static Uri insertReturnUri(Uri uri, ContentValues cv) {
  *   ...
- * }
- * }</pre>
+ * }</code></pre>
  */
 @Retention(CLASS) @Target(METHOD)
 public @interface InsertUri {

--- a/schematic-annotations/src/main/java/net/simonvt/schematic/annotation/MapColumns.java
+++ b/schematic-annotations/src/main/java/net/simonvt/schematic/annotation/MapColumns.java
@@ -24,13 +24,12 @@ import static java.lang.annotation.RetentionPolicy.CLASS;
 
 /**
  * Maps a column or subquery to another column.
- * <pre>{@code
+ * <pre><code>
  * &#064;MapColumns public static Map<String, String> mapColumns() {
  *   Map<String, String> map = new HashMap<String, String>();
  *   map.put(from, to);
  *   return map;
- * }
- * }</pre>
+ * }</code></pre>
  *
  * This is then inserted into the columns in the select statement:
  *

--- a/schematic-annotations/src/main/java/net/simonvt/schematic/annotation/NotificationUri.java
+++ b/schematic-annotations/src/main/java/net/simonvt/schematic/annotation/NotificationUri.java
@@ -25,7 +25,7 @@ import static java.lang.annotation.RetentionPolicy.CLASS;
 /**
  * This {@code Uri} is set as notifications {@code Uri} on the {@code Cursor} returned when querying
  * the defined paths.
- * <pre>{@code
+ * <pre><code>
  * &#064;ContentUri(
  *   path = "lists",
  *   type = "vnd.android.cursor.dir/list",
@@ -35,7 +35,7 @@ import static java.lang.annotation.RetentionPolicy.CLASS;
  *       "lists/withItems"
  *   })
  * public static final Uri LISTS = Uri.parse("content://" + AUTHORITY + "/lists");
- * }</pre>
+ * </code></pre>
  */
 @Retention(CLASS) @Target(FIELD)
 public @interface NotificationUri {

--- a/schematic-annotations/src/main/java/net/simonvt/schematic/annotation/OnConfigure.java
+++ b/schematic-annotations/src/main/java/net/simonvt/schematic/annotation/OnConfigure.java
@@ -24,11 +24,10 @@ import static java.lang.annotation.RetentionPolicy.CLASS;
 
 /**
  * Method to be called when the database connection is being configured.
- * <pre>{@code
+ * <pre><code>
  * &#064;OnConfigure public static void onConfigure(SQLiteDatabase db) {
  *   ...
- * }
- * }</pre>
+ * }</code></pre>
  */
 @Retention(CLASS) @Target(METHOD)
 public @interface OnConfigure {

--- a/schematic-annotations/src/main/java/net/simonvt/schematic/annotation/OnCreate.java
+++ b/schematic-annotations/src/main/java/net/simonvt/schematic/annotation/OnCreate.java
@@ -24,11 +24,10 @@ import static java.lang.annotation.RetentionPolicy.CLASS;
 
 /**
  * Method to be called when creating the database.
- * <pre>{@code
+ * <pre><code>
  * &#064;OnCreate public static void onCreate(Context context, SQLiteDatabase db) {
  *   ...
- * }
- * }</pre>
+ * }</code></pre>
  */
 @Retention(CLASS) @Target(METHOD)
 public @interface OnCreate {

--- a/schematic-annotations/src/main/java/net/simonvt/schematic/annotation/OnUpgrade.java
+++ b/schematic-annotations/src/main/java/net/simonvt/schematic/annotation/OnUpgrade.java
@@ -24,11 +24,10 @@ import static java.lang.annotation.RetentionPolicy.CLASS;
 
 /**
  * Method to be called when upgrading the database.
- * <pre>{@code
+ * <pre><code>
  * &#064;OnUpgrade public static void onUpgrade(SQLiteDatabase db, int oldVersion, int newVersion) {
  *   ...
- * }
- * }</pre>
+ * }</code></pre>
  */
 @Retention(CLASS) @Target(METHOD)
 public @interface OnUpgrade {

--- a/schematic-annotations/src/main/java/net/simonvt/schematic/annotation/References.java
+++ b/schematic-annotations/src/main/java/net/simonvt/schematic/annotation/References.java
@@ -24,10 +24,10 @@ import static java.lang.annotation.RetentionPolicy.CLASS;
 
 /**
  * Adds the REFERENCES clause to a database column.
- * <pre>{@code
+ * <pre><code>
  * &#064;DataType(INTEGER) &#064;References(table = NotesDatabase.LISTS, column = ListColumns._ID)
  * String LIST_ID = "listId";
- * }</pre>
+ * </code></pre>
  */
 @Retention(CLASS) @Target(FIELD)
 public @interface References {

--- a/schematic-annotations/src/main/java/net/simonvt/schematic/annotation/Table.java
+++ b/schematic-annotations/src/main/java/net/simonvt/schematic/annotation/Table.java
@@ -25,9 +25,9 @@ import static java.lang.annotation.RetentionPolicy.CLASS;
 /**
  * Annotate a table name with the interface which contains the columns. This must be a string field
  * inside a class annotated with {@link net.simonvt.schematic.annotation.Database}.
- * <pre>{@code
+ * <pre><code>
  * &#064;Table(ListColumns.class) public static final String LISTS = "lists";
- * }</pre>
+ * </code></pre>
  */
 @Retention(CLASS) @Target(FIELD)
 public @interface Table {

--- a/schematic-annotations/src/main/java/net/simonvt/schematic/annotation/TableEndpoint.java
+++ b/schematic-annotations/src/main/java/net/simonvt/schematic/annotation/TableEndpoint.java
@@ -25,15 +25,14 @@ import static java.lang.annotation.RetentionPolicy.CLASS;
 /**
  * An inner class of a {@link net.simonvt.schematic.annotation.ContentProvider} that contains Uri's
  * which can be queried.
- * <pre>{@code
+ * <pre><code>
  * &#064;TableEndpoint(table = NotesDatabase.LISTS) public static class Lists {
  *
  *   &#064;ContentUri( path = Path.LISTS,
  *   type = "vnd.android.cursor.dir/list",
  *   defaultSort = ListColumns.TITLE + " ASC")
  *   public static final Uri LISTS = buildUri(Path.LISTS);
- * }
- * }</pre>
+ * }</code></pre>
  */
 @Retention(CLASS) @Target(TYPE)
 public @interface TableEndpoint {


### PR DESCRIPTION
Unfortunately, HTML entities such as `&#064;` are displayed incorrectly in a Javadoc.
E.g. we see ```&#064;TableEndpoint(...)``` instead of ```@TableEndpoint(...)```
Current fix ensures that library users will have correct visual info about these annotations.