### PR TITLE
Unique constraint on multiple columns

### DIFF
--- a/schematic-annotations/src/main/java/net/simonvt/schematic/annotation/Constraints.java
+++ b/schematic-annotations/src/main/java/net/simonvt/schematic/annotation/Constraints.java
@@ -1,0 +1,14 @@
+package net.simonvt.schematic.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Specify a list of {@link UniqueConstraint} that should be applied on the table level
+ */
+@Retention(RetentionPolicy.SOURCE) @Target(ElementType.TYPE)
+public @interface Constraints {
+    UniqueConstraint[] unique();
+}

--- a/schematic-annotations/src/main/java/net/simonvt/schematic/annotation/UniqueConstraint.java
+++ b/schematic-annotations/src/main/java/net/simonvt/schematic/annotation/UniqueConstraint.java
@@ -1,0 +1,24 @@
+package net.simonvt.schematic.annotation;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.CLASS;
+
+/** Adds the UNIQUE constraint on a table level */
+@Retention(CLASS) @Target(TYPE)
+public @interface UniqueConstraint {
+
+    /** Optional name for constraint */
+    String name() default "";
+
+    /** Column names to be used in constraint */
+    String[] columns();
+
+    /**
+     * Defines conflict resolution algorithm.
+     * By default {@link ConflictResolutionType#NONE} is used.
+     * */
+    ConflictResolutionType onConflict() default ConflictResolutionType.NONE;
+}

--- a/schematic-samples/src/main/java/net/simonvt/schematic/sample/database/NotesDatabase.java
+++ b/schematic-samples/src/main/java/net/simonvt/schematic/sample/database/NotesDatabase.java
@@ -38,6 +38,8 @@ public final class NotesDatabase {
   public static class Tables {
 
     @Table(ListColumns.class) @IfNotExists public static final String LISTS = "lists";
+
+    @Table(TagColumns.class) @IfNotExists public static final String NOTES_TAGS = "notes_tags";
   }
 
   @Table(NoteColumns.class) public static final String NOTES = "notes";

--- a/schematic-samples/src/main/java/net/simonvt/schematic/sample/database/NotesProvider.java
+++ b/schematic-samples/src/main/java/net/simonvt/schematic/sample/database/NotesProvider.java
@@ -49,6 +49,7 @@ public final class NotesProvider {
     String LISTS = "lists";
     String NOTES = "notes";
     String FROM_LIST = "fromList";
+    String TAGS = "tags";
   }
 
   private static Uri buildUri(String... paths) {
@@ -165,6 +166,20 @@ public final class NotesProvider {
       return new Uri[] {
           withId(noteId), fromList(listId), Lists.withId(listId),
       };
+    }
+  }
+
+  @TableEndpoint(table = Tables.NOTES_TAGS)
+  public static class NotesTags {
+    @InexactContentUri(
+        name = "TAGS_FOR_NOTE",
+        path = Path.NOTES + "/#/" + Path.TAGS,
+        type = "vnd.android.cursor.dir/note/tags",
+        whereColumn = TagColumns.NOTE_ID,
+        pathSegment = 1
+    )
+    public static Uri fromNote(long noteId) {
+      return buildUri(Path.NOTES, String.valueOf(noteId), Path.TAGS);
     }
   }
 }

--- a/schematic-samples/src/main/java/net/simonvt/schematic/sample/database/TagColumns.java
+++ b/schematic-samples/src/main/java/net/simonvt/schematic/sample/database/TagColumns.java
@@ -1,0 +1,34 @@
+package net.simonvt.schematic.sample.database;
+
+import net.simonvt.schematic.annotation.AutoIncrement;
+import net.simonvt.schematic.annotation.Constraints;
+import net.simonvt.schematic.annotation.DataType;
+import net.simonvt.schematic.annotation.DataType.Type;
+import net.simonvt.schematic.annotation.NotNull;
+import net.simonvt.schematic.annotation.PrimaryKey;
+import net.simonvt.schematic.annotation.References;
+import net.simonvt.schematic.annotation.UniqueConstraint;
+
+import static net.simonvt.schematic.annotation.ConflictResolutionType.REPLACE;
+
+@Constraints(
+    unique = @UniqueConstraint(
+            name = "UNQ_TAG_FOR_NOTE",
+            columns = {TagColumns.NOTE_ID, TagColumns.NAME},
+            onConflict = REPLACE)
+)
+public interface TagColumns {
+  @DataType(Type.INTEGER)
+  @PrimaryKey
+  @AutoIncrement
+  String ID = "_id";
+
+  @DataType(Type.INTEGER)
+  @NotNull
+  @References(table = NotesDatabase.NOTES, column = NoteColumns.ID)
+  String NOTE_ID = "note_id";
+
+  @DataType(Type.TEXT)
+  @NotNull
+  String NAME = "name";
+}

--- a/schematic-samples/src/main/res/layout/fragment_note.xml
+++ b/schematic-samples/src/main/res/layout/fragment_note.xml
@@ -48,6 +48,12 @@
       <requestFocus/>
     </EditText>
   </FrameLayout>
+  <EditText
+      android:id="@+id/tags"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:hint="comma separated list of tags"
+      />
 
   <LinearLayout
       android:id="@+id/action"


### PR DESCRIPTION
Addresses issue #54 

Two ways to specify unique constraint on table level

``` java
@UniqueConstraint(columns = {TagColumns.NOTE_ID, TagColumns.NAME}, onConflict = REPLACE)
public interface TagColumns {
```

or

``` java
@Constraints(
    @UniqueConstraint(columns = {TagColumns.NOTE_ID, TagColumns.NAME}, onConflict = REPLACE)
)
public interface TagColumns {
```

The last one allows to specify multiple unique constraints.
Full example. Table definition:

``` java
@Constraints(
    @UniqueConstraint(columns = {TagColumns.NOTE_ID, TagColumns.NAME}, onConflict = REPLACE)
)
public interface TagColumns {
  @DataType(Type.INTEGER)
  @PrimaryKey
  @AutoIncrement
  String ID = "_id";

  @DataType(Type.INTEGER)
  @NotNull
  @References(table = NotesDatabase.NOTES, column = NoteColumns.ID)
  String NOTE_ID = "note_id";

  @DataType(Type.TEXT)
  @NotNull
  String NAME = "name";
}
```

The generated code will looks like:

``` java
public static final String NOTES_TAGS = "CREATE TABLE IF NOT EXISTS notes_tags ("
   + TagColumns.ID + " INTEGER PRIMARY KEY AUTOINCREMENT,"
   + TagColumns.NOTE_ID + " INTEGER NOT NULL REFERENCES notes(_id),"
   + TagColumns.NAME + " TEXT NOT NULL,"
   + " UNIQUE ( note_id, name ) ON CONFLICT REPLACE)";
```
