### PR TITLE
Extend support for constraints on table level

### DIFF
--- a/schematic-annotations/src/main/java/net/simonvt/schematic/annotation/Check.java
+++ b/schematic-annotations/src/main/java/net/simonvt/schematic/annotation/Check.java
@@ -11,6 +11,7 @@ import static java.lang.annotation.RetentionPolicy.CLASS;
  * Add CHECK constraint. Can be used on column level or on table level.
  * <pre>
  * <code>
+ *
  * &#64;Check(NotesColumns.STATUS + " = '" + NotesColumns.STATUS_COMPLETED + "' and " + NotesColumns.COMPLETION_DATE + " is not null")
  * public interface NotesColumns{
  *   String STATUS_NEW = "new";
@@ -28,4 +29,7 @@ public @interface Check {
      * CHECK constraint text. Shouldn't contain double quotes. Use single quote instead.
      */
     String value();
+
+    /** optional name for constraint*/
+    String name() default "";
 }

--- a/schematic-annotations/src/main/java/net/simonvt/schematic/annotation/Constraints.java
+++ b/schematic-annotations/src/main/java/net/simonvt/schematic/annotation/Constraints.java
@@ -10,5 +10,13 @@ import java.lang.annotation.Target;
  */
 @Retention(RetentionPolicy.SOURCE) @Target(ElementType.TYPE)
 public @interface Constraints {
-    UniqueConstraint[] unique();
+
+    /** list of unique constraints */
+    UniqueConstraint[] unique() default {};
+
+    /** list of check constraints */
+    Check[] check() default {};
+
+    /** list of foreign key constraints */
+    ForeignKeyConstraint[] foreignKey() default {};
 }

--- a/schematic-annotations/src/main/java/net/simonvt/schematic/annotation/ForeignKeyConstraint.java
+++ b/schematic-annotations/src/main/java/net/simonvt/schematic/annotation/ForeignKeyConstraint.java
@@ -1,0 +1,29 @@
+package net.simonvt.schematic.annotation;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.CLASS;
+
+/** Adds FOREIGN KEY constraint on table level */
+@Retention(CLASS) @Target(TYPE)
+public @interface ForeignKeyConstraint {
+    /** Optional name for constraint */
+    String name() default "";
+
+    /** Column names to be used in constraint */
+    String[] columns();
+
+    /** Name of referenced table */
+    String referencedTable();
+
+    /** Column names in referenced table */
+    String[] referencedColumns();
+
+    /**
+     * Defines conflict resolution algorithm.
+     * By default {@link ConflictResolutionType#NONE} is used.
+     * */
+    ConflictResolutionType onConflict() default ConflictResolutionType.NONE;
+}

--- a/schematic-annotations/src/main/java/net/simonvt/schematic/annotation/PrimaryKeyConstraint.java
+++ b/schematic-annotations/src/main/java/net/simonvt/schematic/annotation/PrimaryKeyConstraint.java
@@ -1,0 +1,25 @@
+package net.simonvt.schematic.annotation;
+
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.CLASS;
+
+/** Adds the PRIMARY KEY constraint on a table level */
+@Retention(CLASS) @Target(TYPE)
+public @interface PrimaryKeyConstraint {
+
+    /** Optional name for constraint */
+    String name() default "";
+
+    /** Column names to be used in constraint */
+    String[] columns();
+
+    /**
+     * Defines conflict resolution algorithm.
+     * By default {@link ConflictResolutionType#NONE} is used.
+     * */
+    ConflictResolutionType onConflict() default ConflictResolutionType.NONE;
+}

--- a/schematic-samples/src/main/java/net/simonvt/schematic/sample/database/NoteColumns.java
+++ b/schematic-samples/src/main/java/net/simonvt/schematic/sample/database/NoteColumns.java
@@ -38,8 +38,7 @@ public interface NoteColumns {
   @DataType(TEXT) String NOTE = "note";
 
   @DataType(TEXT)
-  @Check(NoteColumns.STATUS + " in ('" + NoteColumns.STATUS_NEW + "', '"
-          + NoteColumns.STATUS_COMPLETED + "')")
+  @Check(NoteColumns.STATUS + " in ('" + STATUS_NEW + "', '" + STATUS_COMPLETED + "')")
   String STATUS = "status";
 
 }


### PR DESCRIPTION
* Allow multiple check constraints on table level
* Primary key on table level. It allows to define multi column primary key constraint with conflict resolution strategy
* Foreign key can on table level. It allows to define multi column foreign key constraint.

Closes #65  