### PR TITLE
Add support to Foreign Key actions "ON UPDATE" and "ON DELETE"

### DIFF
--- a/schematic-annotations/src/main/java/net/simonvt/schematic/annotation/ForeignKeyAction.java
+++ b/schematic-annotations/src/main/java/net/simonvt/schematic/annotation/ForeignKeyAction.java
@@ -1,0 +1,13 @@
+package net.simonvt.schematic.annotation;
+
+/**
+ * Action triggered with foreign key ON DELETE and ON UPDATE clauses.
+ */
+public enum ForeignKeyAction {
+  NONE,
+  NO_ACTION,
+  RESTRICT,
+  SET_NULL,
+  SET_DEFAULT,
+  CASCADE,
+}

--- a/schematic-annotations/src/main/java/net/simonvt/schematic/annotation/ForeignKeyConstraint.java
+++ b/schematic-annotations/src/main/java/net/simonvt/schematic/annotation/ForeignKeyConstraint.java
@@ -21,9 +21,8 @@ public @interface ForeignKeyConstraint {
     /** Column names in referenced table */
     String[] referencedColumns();
 
-    /**
-     * Defines conflict resolution algorithm.
-     * By default {@link ConflictResolutionType#NONE} is used.
-     * */
-    ConflictResolutionType onConflict() default ConflictResolutionType.NONE;
+
+    ForeignKeyAction onDelete() default ForeignKeyAction.NONE;
+
+    ForeignKeyAction onUpdate() default ForeignKeyAction.NONE;
 }

--- a/schematic-annotations/src/main/java/net/simonvt/schematic/annotation/References.java
+++ b/schematic-annotations/src/main/java/net/simonvt/schematic/annotation/References.java
@@ -34,4 +34,8 @@ public @interface References {
   String table();
 
   String column();
+
+  ForeignKeyAction onDelete() default ForeignKeyAction.NONE;
+
+  ForeignKeyAction onUpdate() default ForeignKeyAction.NONE;
 }

--- a/schematic-sample-kotlin/src/main/java/net/simonvt/schematic/sample/database/NoteColumns.kt
+++ b/schematic-sample-kotlin/src/main/java/net/simonvt/schematic/sample/database/NoteColumns.kt
@@ -16,13 +16,9 @@
 
 package net.simonvt.schematic.sample.database
 
-import net.simonvt.schematic.annotation.AutoIncrement
-import net.simonvt.schematic.annotation.Check
-import net.simonvt.schematic.annotation.DataType
+import net.simonvt.schematic.annotation.*
 import net.simonvt.schematic.annotation.DataType.Type.INTEGER
 import net.simonvt.schematic.annotation.DataType.Type.TEXT
-import net.simonvt.schematic.annotation.PrimaryKey
-import net.simonvt.schematic.annotation.References
 import net.simonvt.schematic.sample.database.NotesDatabase.Tables
 
 interface NoteColumns {
@@ -32,7 +28,8 @@ interface NoteColumns {
 
     @DataType(INTEGER) @PrimaryKey @AutoIncrement const val ID = "_id"
 
-    @DataType(INTEGER) @References(table = Tables.LISTS, column = ListColumns.ID)
+    @DataType(INTEGER) @References(table = Tables.LISTS, column = ListColumns.ID,
+            onDelete = ForeignKeyAction.CASCADE)
     const val LIST_ID = "listId"
 
     @DataType(TEXT) const val NOTE = "note"

--- a/schematic-sample-kotlin/src/main/java/net/simonvt/schematic/sample/database/TagColumns.kt
+++ b/schematic-sample-kotlin/src/main/java/net/simonvt/schematic/sample/database/TagColumns.kt
@@ -1,14 +1,8 @@
 package net.simonvt.schematic.sample.database
 
-import net.simonvt.schematic.annotation.AutoIncrement
+import net.simonvt.schematic.annotation.*
 import net.simonvt.schematic.annotation.ConflictResolutionType.REPLACE
-import net.simonvt.schematic.annotation.Constraints
-import net.simonvt.schematic.annotation.DataType
 import net.simonvt.schematic.annotation.DataType.Type
-import net.simonvt.schematic.annotation.NotNull
-import net.simonvt.schematic.annotation.PrimaryKey
-import net.simonvt.schematic.annotation.References
-import net.simonvt.schematic.annotation.UniqueConstraint
 
 @Constraints(
     unique = arrayOf(
@@ -24,7 +18,8 @@ interface TagColumns {
     @DataType(Type.INTEGER) @PrimaryKey @AutoIncrement const val ID = "_id"
 
     @DataType(Type.INTEGER) @NotNull
-    @References(table = NotesDatabase.NOTES, column = NoteColumns.ID)
+    @References(table = NotesDatabase.NOTES, column = NoteColumns.ID,
+            onDelete = ForeignKeyAction.CASCADE)
     const val NOTE_ID = "note_id"
 
     @DataType(Type.TEXT) @NotNull

--- a/schematic-sample/src/main/java/net/simonvt/schematic/sample/database/NoteColumns.java
+++ b/schematic-sample/src/main/java/net/simonvt/schematic/sample/database/NoteColumns.java
@@ -20,6 +20,7 @@ import net.simonvt.schematic.annotation.AutoIncrement;
 import net.simonvt.schematic.annotation.Check;
 import net.simonvt.schematic.annotation.DataType;
 import net.simonvt.schematic.annotation.PrimaryKey;
+import net.simonvt.schematic.annotation.ForeignKeyAction;
 import net.simonvt.schematic.annotation.References;
 import net.simonvt.schematic.sample.database.NotesDatabase.Tables;
 
@@ -32,8 +33,8 @@ public interface NoteColumns {
 
   @DataType(INTEGER) @PrimaryKey @AutoIncrement String ID = "_id";
 
-  @DataType(INTEGER) @References(table = Tables.LISTS, column = ListColumns.ID) String LIST_ID =
-      "listId";
+  @DataType(INTEGER) @References(table = Tables.LISTS, column = ListColumns.ID,
+          onDelete = ForeignKeyAction.CASCADE) String LIST_ID = "listId";
 
   @DataType(TEXT) String NOTE = "note";
 

--- a/schematic-sample/src/main/java/net/simonvt/schematic/sample/database/TagColumns.java
+++ b/schematic-sample/src/main/java/net/simonvt/schematic/sample/database/TagColumns.java
@@ -6,6 +6,7 @@ import net.simonvt.schematic.annotation.DataType;
 import net.simonvt.schematic.annotation.DataType.Type;
 import net.simonvt.schematic.annotation.NotNull;
 import net.simonvt.schematic.annotation.PrimaryKey;
+import net.simonvt.schematic.annotation.ForeignKeyAction;
 import net.simonvt.schematic.annotation.References;
 import net.simonvt.schematic.annotation.UniqueConstraint;
 
@@ -25,7 +26,8 @@ public interface TagColumns {
 
   @DataType(Type.INTEGER)
   @NotNull
-  @References(table = NotesDatabase.NOTES, column = NoteColumns.ID)
+  @References(table = NotesDatabase.NOTES, column = NoteColumns.ID,
+          onDelete = ForeignKeyAction.CASCADE)
   String NOTE_ID = "note_id";
 
   @DataType(Type.TEXT)


### PR DESCRIPTION
Added support to Foreign Key constraints actions on clauses "ON UPDATE" and "ON DELETE", following this specification: https://www.sqlite.org/foreignkeys.html#fk_actions