### PR TITLE
Update README.md to reflect updates to gradle

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Including in your project
 ```groovy
 dependencies {
   annotationProcessor 'net.simonvt.schematic:schematic-compiler:{latest-version}'
-  compile 'net.simonvt.schematic:schematic:{latest-version}'
+  api 'net.simonvt.schematic:schematic:{latest-version}'
 }
 ```
 


### PR DESCRIPTION
Use of `compile` is deprecated.